### PR TITLE
[MRG] test functions in drop_unique_hashes

### DIFF
--- a/distillerycats/drop_unique_hashes.py
+++ b/distillerycats/drop_unique_hashes.py
@@ -6,32 +6,35 @@ from sourmash import sourmash_args
 from collections import Counter
 
 
+
+
+def drop_below_mincount(hashCounter, min_count):
+    for hashes, cnts in hashCounter.copy().items():
+        if cnts < min_count:
+            hashCounter.pop(hashes)
+    return hashCounter
+
+def build_hashCounter(sigs, hashCounter):
+    for sig in sigs:
+        hashCounter.update(sig.minhash.hashes) # add hashes to Counter
+    return hashCounter
+
+
 def main(args):
     min_count = args.minimum_count
-    # select sigs that match specified ksize, moltype. Store hashes.
+    # select sigs that match specified ksize, moltype.
     sigs = sourmash_args.load_file_as_signatures(args.signatures_file, ksize=args.ksize, select_moltype=args.alphabet)
 
-    fresh_mh = sigs[0].minhash.copy_and_clear()
+    # count hashes
     counts = Counter()
-    #hashes = []
-    for sig in sigs:
-        counts.update(sig.minhash.hashes)
-        #hashes+= sig.minhash.hashes # Get the minhashes
-
-    #counts = Counter(hashes)
+    counts = build_hashCounter(sigs, counts)
     print(f"dropping unique hashes for molecule: {args.alphabet}, ksize: {args.ksize}")
-    for hashes, cnts in counts.copy().items():
-        if cnts < min_count:
-            counts.pop(hashes)
-
-    # write out hashes
-    #if args.output_hashes:
-    #    with open(args.output_hashes, "w") as out:
-    #        for key in counts:
-    #            print(key, file=out)
+    # drop hashes below min_count threshold
+    counts = drop_hashes(counts, min_count)
 
     # write out sig
     if args.output_sig:
+        fresh_mh = sigs[0].minhash.copy_and_clear()
         # add hashes to fresh_mh
         fresh_mh.add_many(counts.keys())
         # build sig
@@ -49,11 +52,11 @@ def cmdline(sys_args):
     p.add_argument('--ksize', help='ksize', default=31)
 
     # output options:
-    #p.add_argument('--output-hashes', help='store list of hashes')
     p.add_argument('--output', help='store abundance filtered hashes as signature')
     args = p.parse_args()
 
     return main(args)
+
 
 # execute this, when run with `python -m`.
 if __name__ == '__main__':

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
    - sourmash>=4.1,<5
    - pandas=1.2.4
    - feather-format=0.4.1
+   - pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --doctest-glob='doc/*.md' --ignore=setup.py
+python_files = distillerycats/*.py tests/*.py
+norecursedirs = utils build buildenv .tox .asv .eggs .snakemake .buildenv bak

--- a/tests/test_drop_unique_hashes.py
+++ b/tests/test_drop_unique_hashes.py
@@ -1,0 +1,53 @@
+""" test drop_unique_hashes.py"""
+
+from collections import Counter
+from sourmash import MinHash, SourmashSignature
+from distillerycats.drop_unique_hashes import build_hashCounter, drop_below_mincount
+
+
+def test_build_hashCounter():
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh1.add_many((1, 2, 3, 4))
+    mh2.add_many((1, 2, 5))
+    true_res=Counter({1: 2, 2: 2, 3: 1, 4: 1, 5: 1})
+
+    ss1 = SourmashSignature(mh1)
+    ss2 = SourmashSignature(mh2)
+
+    counts = Counter()
+    hc = build_hashCounter([ss1,ss2], counts)
+    print("Hash Counter: ", hc)
+    assert hc == true_res
+
+def test_drop_below_mincount():
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh1.add_many((1, 2, 3, 4))
+    mh2.add_many((1, 2, 5))
+
+    ss1 = SourmashSignature(mh1)
+    ss2 = SourmashSignature(mh2)
+
+    counts = Counter()
+    hc = build_hashCounter([ss1,ss2], counts)
+    kept_hashes = drop_below_mincount(hc, 2)
+    true_kept = Counter({1: 2, 2: 2})
+    print("kept hashes: ", kept_hashes)
+    assert kept_hashes == true_kept
+
+def test_drop_below_mincount_threshold():
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh1.add_many((1, 2, 3, 4))
+    mh2.add_many((1, 1, 2, 5))
+
+    ss1 = SourmashSignature(mh1)
+    ss2 = SourmashSignature(mh2)
+
+    counts = Counter()
+    hc = build_hashCounter([ss1,ss2], counts)
+    kept_hashes = drop_below_mincount(hc, 3)
+    true_kept = Counter({1: 3})
+    print("kept hashes: ", kept_hashes)
+    assert kept_hashes == true_kept


### PR DESCRIPTION
- init `tests` folder
- add tests for the internal functions in `drop_unique_hashes`

note - yes, we should do an integration test that the command line call works, but I can add that after we have some testing data in place